### PR TITLE
Use /usr/bin/env

### DIFF
--- a/passpwn
+++ b/passpwn
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 


### PR DESCRIPTION
I'm not sure if you want this, see [this answer](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my#29620) for the pros and cons, but it should allow the script to be run on a larger number of systems, including my own, where bash is not in the expected place (but `/usr/bin/env` is, as an exception).

```console
$ whereis bash
bash: /nix/store/idaq9banzih5n5fjx8kgcfnlfd5qf8mf-system-path/bin/bash
```