### PR TITLE
Quote ./*.gpg argument for git-ls-files

### DIFF
--- a/passpwn
+++ b/passpwn
@@ -31,7 +31,7 @@ function main() {
 	# Set IFS to be able to cope with spaces in file names.
 	IFS=$'\n'
 
-	for pass_entry in $(pass git ls-files ./*.gpg); do
+	for pass_entry in $(pass git ls-files './*.gpg'); do
 
 		# Support characters with åäö etc..
 		escaped_entry="$(printf %b "${pass_entry}")"


### PR DESCRIPTION
Without those quotes, the argument will be evaluated by bash instead of
git-ls-files, leading to incorrect results:

```
$ cd passpwn-test/
[passpwn-test]$ touch bla.gpg
[passpwn-test]$ bash -x /usr/local/bin/passpwn
+ set -eou pipefail
+ main
+ IFS='
'
++ pass git ls-files ./bla.gpg
```